### PR TITLE
Add prepublish Script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "npm -s run clean && tsc",
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "prepublish": "tsc"
   },
   "devDependencies": {
     "@types/node": "^14.0.22",


### PR DESCRIPTION
Typescript needs to be built before `npm publish`.
I added `prepublish` script to `package.json` file, so it is done automatically.
Reference: https://medium.com/cameron-nokes/the-30-second-guide-to-publishing-a-typescript-package-to-npm-89d93ff7bccd

Closes #3

