### PR TITLE
FIX: Cursor Id validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ query {
 `include` (optional) \
 : Receive include option of Prisma
 
+`select` (optional) \
+: Receive select option of Prisma
+
 `prisma` \
 : Receive prisma object
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-offset-pagination",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "prisma-offset-pagination",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/paginator/pageEdge.ts
+++ b/src/paginator/pageEdge.ts
@@ -19,6 +19,7 @@ interface Props<T> {
   orderBy?: string;
   orderDirection?: 'asc' | 'desc';
   include?: any;
+  select:?: any;
   where?: any;
   prisma: any;
 }
@@ -67,8 +68,11 @@ export async function prismaOffsetPagination({
   if (orderBy) {
     findManyArgs = { ...findManyArgs, orderBy: { [orderBy]: orderDirection } };
   }
-  if (include) {
+  if (include && !select) {
     findManyArgs = { ...findManyArgs, include: include };
+  }
+  if (select && !include) {
+    findManyArgs = { ...findManyArgs, select: select };
   }
 
   // cursor & currentPage

--- a/src/paginator/pageEdge.ts
+++ b/src/paginator/pageEdge.ts
@@ -76,7 +76,7 @@ export async function prismaOffsetPagination({
   if (cursor) {
     const prismaModel = prisma[model.name.toLowerCase()];
     const decryptedCursor = Buffer.from(cursor, 'base64').toString('ascii').slice(9);
-    let idOrigin: number | string = isNaN(parseInt(decryptedCursor)) ? decryptedCursor : Number(decryptedCursor);
+    let idOrigin: number | string = isNaN(Number(decryptedCursor)) ? decryptedCursor : Number(decryptedCursor);
 
     // findManyArgsForCursorCount -> cursorCount -> currentPage
     let findManyArgsForCursorCount: Record<string, any>;

--- a/src/paginator/pageEdge.ts
+++ b/src/paginator/pageEdge.ts
@@ -19,7 +19,7 @@ interface Props<T> {
   orderBy?: string;
   orderDirection?: 'asc' | 'desc';
   include?: any;
-  select:?: any;
+  select?: any;
   where?: any;
   prisma: any;
 }

--- a/src/paginator/pageEdge.ts
+++ b/src/paginator/pageEdge.ts
@@ -32,6 +32,7 @@ export async function prismaOffsetPagination({
   orderBy,
   orderDirection,
   include,
+  select,
   where,
   prisma,
 }: Props<typeof model>): Promise<PaginationType> {


### PR DESCRIPTION
This fix is related to issue: https://github.com/prisma-korea/prisma-offset-pagination/issues/9

When your table does not have a sequential primary key (like my case that is UUID), the `decryptedCursor` inside of a `parseInt()` always results into a number excepting the first page.

**Sample with parseInt():**
```js
const cursors = ['c2FsdHlzYWx0YjhlZTZhMjMtNjcxYi00MTAxLThkMzgtYzFkZmNkZWM5ZDRk', 'c2FsdHlzYWx0NmJkMDk0YTQtYmY2Zi00YTg1LThlNDItOWNlYTYyNjlhYTI0', 'c2FsdHlzYWx0NzBlN2Q1NTgtZjY5MS00OTEyLTk3ZGItOTI5NDkyYzQwMzhi', 'c2FsdHlzYWx0MjU1ZTcwODYtNmQ0Yy00OWYyLWFjYTctYTYxYjljMTNkZGVj'];

cursors.forEach((cursor) => {
    const decryptedCursor = Buffer.from(cursor, 'base64').toString('ascii').slice(9);
    console.log(parseInt(decryptedCursor))
});
// output: NaN | 6 | 70 | 255
// All these should console as NaN
```
This behaviour leads to a falsy `FALSE` condition giving the `idOrigin` variable the NaN value resulting the error:

```console
Argument id: Got invalid value NaN on prisma.model. Provided Float, expected String.
```
Instead of using the `parseInt(decryptedCursor)` we need use the `Number(decryptedCursor)` on ternary condition

**Sample with Number():**
```js
const cursors = ['c2FsdHlzYWx0YjhlZTZhMjMtNjcxYi00MTAxLThkMzgtYzFkZmNkZWM5ZDRk', 'c2FsdHlzYWx0NmJkMDk0YTQtYmY2Zi00YTg1LThlNDItOWNlYTYyNjlhYTI0', 'c2FsdHlzYWx0NzBlN2Q1NTgtZjY5MS00OTEyLTk3ZGItOTI5NDkyYzQwMzhi', 'c2FsdHlzYWx0MjU1ZTcwODYtNmQ0Yy00OWYyLWFjYTctYTYxYjljMTNkZGVj', 
'c2FsdHlzYWx0Mg==', //Here is a encrypted cursor from a table with sequential id
'c2FsdHlzYWx0MjM3', //Here is a encrypted cursor from a table with sequential id
'c2FsdHlzYWx0MjMy' //Here is a encrypted cursor from a table with sequential id
];  

cursors.forEach((cursor) => {
    const decryptedCursor = Buffer.from(cursor, 'base64').toString('ascii').slice(9);
    console.log(Number(decryptedCursor))
});
// output: NaN | NaN | NaN | NaN | 2 | 237 | 232
```
